### PR TITLE
fixing unrecognised selector crash

### DIFF
--- a/RHManagedObject.m
+++ b/RHManagedObject.m
@@ -284,7 +284,13 @@
 }
 
 -(id)objectInCurrentThreadContext {
-	NSManagedObjectContext *currentMoc = [[self class] performSelector:@selector(managedObjectContextForCurrentThread)];
+	//NSManagedObjectContext *currentMoc = [[self class] performSelector:@selector(managedObjectContextForCurrentThread)];
+	NSError *error = nil;
+    NSManagedObjectContext *currentMoc = [[self class] managedObjectContextForCurrentThreadWithError:&error];
+    if(error)
+    {
+        NSLog(@"%@", error);
+    }
 	return [currentMoc objectWithID:self.objectID];
 }
 


### PR DESCRIPTION
This was causing a crash for me and rightly so since there's no method that doesn't take an error parameter. This fixes the crash without changing API.
