### PR TITLE
RHManagedObject.m create entity fix 

### DIFF
--- a/RHManagedObject/RHManagedObject.m
+++ b/RHManagedObject/RHManagedObject.m
@@ -35,7 +35,7 @@
 @synthesize didDeleteBlock;
 
 +(NSString *)entityName {
-    return NSStringFromClass([self superclass]);
+    return NSStringFromClass([self class]);
 }
 
 // Abstract class.  Implement in your entity subclass to return the name of the model without the .xcdatamodeld extension.


### PR DESCRIPTION
If I have a class Entity. And MyEntity inherits from Entity.
Then when I call
MyEntity *c = [MyEntity newEntityWithError:nil];
c.myProperty = @"test";
I get an error "Entity doesn't have property with name "myProperty".
